### PR TITLE
Expose few kBeacon method, to allow object creation and connection without scanning

### DIFF
--- a/kbeaconlib2/Classes/KBeacon.swift
+++ b/kbeaconlib2/Classes/KBeacon.swift
@@ -290,7 +290,7 @@ public typealias onActionComplete = (_ result:Bool, _ error:KBException?)->Void
     //buffer size
     private static let MAX_BUFFER_DATA_SIZE = 1024
     
-    internal override init()
+    public override init()
     {
         mNotifyData2ClassMap = [Int:NotifyDataDelegate]()
         mActionStatus = ActionType.ACTION_IDLE
@@ -302,7 +302,7 @@ public typealias onActionComplete = (_ result:Bool, _ error:KBException?)->Void
         mCfgMgr = KBCfgHandler()
     }
     
-    internal func attach2Device(peripheral:CBPeripheral, beaconMgr:KBeaconsMgr)
+    public func attach2Device(peripheral:CBPeripheral, beaconMgr:KBeaconsMgr)
     {
         cbPeripheral = peripheral
         peripheral.delegate = self
@@ -850,7 +850,7 @@ public typealias onActionComplete = (_ result:Bool, _ error:KBException?)->Void
         return KBCfgHandler.createCfgSensorObject(sensorType)
     }
     
-    internal func parseAdvPacket(advData:[String:Any], rssi:Int8)->Bool
+    public func parseAdvPacket(advData:[String:Any], rssi:Int8)->Bool
     {
         if let beaconName = advData["kCBAdvDataLocalName"] as? String{
             self.name = beaconName


### PR DESCRIPTION
This is a fix for https://github.com/kkmhogen/kbeaconlib2/issues/1 

With this PR, with the following code snippet, you can easily reconnect without a scan.

```
// Retrieve advertisement data from stored info
let advData = model.advertisementData
// set CBPeripheral uuid
let uuidString = model.peripheral?.identifier.uuidString
let uuid = UUID(uuidString: uuidString)

// Retrieve peripheral from CBCentralManager
let peripheral = beaconMgr.cbBeaconMgr.retrievePeripherals(withIdentifiers: [uuid]).first

let pUnknownBeacon = KBeacon()
_ = pUnknownBeacon.parseAdvPacket(advData: advData, rssi: Int8(truncating: model.rssi))
pUnknownBeacon.attach2Device(peripheral: peripheral, beaconMgr: beaconMgr)
beaconMgr.beacons[uuidString] = pUnknownBeacon

pUnknownBeacon.connect("0000000000000000", timeout: timeout, delegate: self)
```